### PR TITLE
Pad in metamer generation, correction to pooling region size calculation

### DIFF
--- a/odak/learn/perception/blur_loss.py
+++ b/odak/learn/perception/blur_loss.py
@@ -15,7 +15,7 @@ class BlurLoss():
 
 
     def __init__(self, device=torch.device("cpu"),
-                 alpha=0.08, real_image_width=0.2, real_viewing_distance=0.7, mode="quadratic", blur_source=False):
+                 alpha=0.2, real_image_width=0.2, real_viewing_distance=0.7, mode="quadratic", blur_source=False):
         """
         Parameters
         ----------

--- a/odak/learn/perception/foveation.py
+++ b/odak/learn/perception/foveation.py
@@ -130,7 +130,7 @@ def make_pooling_size_map_pixels(gaze_location, image_pixel_size, alpha=0.3, rea
     major_axis = (torch.tan(angle_max) - torch.tan(angle_min)) / \
         real_viewing_distance
     minor_axis = 2 * distance_to_pixel * torch.tan(pooling_rad*0.5)
-    area = math.pi * major_axis * minor_axis
+    area = math.pi * major_axis * minor_axis * 0.25
     # Should be +ve anyway, but check to ensure we don't take sqrt of negative number
     area = torch.abs(area)
     pooling_real = torch.sqrt(area)

--- a/odak/learn/perception/metamer_mse_loss.py
+++ b/odak/learn/perception/metamer_mse_loss.py
@@ -16,7 +16,7 @@ class MetamerMSELoss():
 
 
     def __init__(self, device=torch.device("cpu"),
-                 alpha=0.08, real_image_width=0.2, real_viewing_distance=0.7, mode="quadratic",
+                 alpha=0.2, real_image_width=0.2, real_viewing_distance=0.7, mode="quadratic",
                  n_pyramid_levels=5, n_orientations=2):
         """
         Parameters

--- a/odak/learn/perception/metamer_mse_loss.py
+++ b/odak/learn/perception/metamer_mse_loss.py
@@ -67,6 +67,7 @@ class MetamerMSELoss():
                 The generated metamer image
         """
         image = rgb_2_ycrcb(image)
+        image_size = image.size()
         image = pad_image_for_pyramid(image, self.metameric_loss.n_pyramid_levels)
 
         target_stats = self.metameric_loss.calc_statsmaps(
@@ -104,6 +105,8 @@ class MetamerMSELoss():
         metamer = self.metameric_loss.pyramid_maker.reconstruct_from_pyramid(
             noise_pyramid)
         metamer = ycrcb_2_rgb(metamer)
+        # Crop to remove any padding
+        metamer = metamer[:image_size[0], :image_size[1], :image_size[2], :image_size[3]]
         return metamer
 
     def __call__(self, image, target, gaze=[0.5, 0.5]):

--- a/odak/learn/perception/metameric_loss.py
+++ b/odak/learn/perception/metameric_loss.py
@@ -18,7 +18,7 @@ class MetamericLoss():
     """
 
 
-    def __init__(self, device=torch.device('cpu'), alpha=0.08, real_image_width=0.2,
+    def __init__(self, device=torch.device('cpu'), alpha=0.2, real_image_width=0.2,
                  real_viewing_distance=0.7, n_pyramid_levels=5, mode="quadratic",
                  n_orientations=2, use_l2_foveal_loss=True, fovea_weight=20.0, use_radial_weight=False,
                  use_fullres_l0=False):

--- a/odak/learn/perception/metameric_loss.py
+++ b/odak/learn/perception/metameric_loss.py
@@ -3,7 +3,7 @@ import torch
 import math
 
 from .color_conversion import ycrcb_2_rgb, rgb_2_ycrcb
-from .spatial_steerable_pyramid import SpatialSteerablePyramid
+from .spatial_steerable_pyramid import SpatialSteerablePyramid, pad_image_for_pyramid
 from .radially_varying_blur import RadiallyVaryingBlur
 from .foveation import make_radial_map
 
@@ -213,17 +213,8 @@ class MetamericLoss():
             raise Exception(
                 "MetamericLoss ERROR: Input and target must have same number of channels.")
         # Pad image and target if necessary
-        min_divisor = 2**self.n_pyramid_levels
-        height = image.size(2)
-        width = image.size(3)
-        required_height = math.ceil(height/min_divisor)*min_divisor
-        required_width = math.ceil(width/min_divisor)*min_divisor
-        if required_height > height or required_width > width:
-            # We need to pad!
-            pad = torch.nn.ReflectionPad2d(
-                (0, 0, required_height-height, required_width-width))
-            image = pad(image)
-            target = pad(target)
+        image = pad_image_for_pyramid(image, self.n_pyramid_levels)
+        target = pad_image_for_pyramid(target, self.n_pyramid_levels)
         if image.size(1) == 3 and image_colorspace == "RGB":
             image = rgb_2_ycrcb(image)
             target = rgb_2_ycrcb(target)

--- a/odak/learn/perception/metameric_loss_uniform.py
+++ b/odak/learn/perception/metameric_loss_uniform.py
@@ -3,7 +3,7 @@ import torch
 import math
 
 from .color_conversion import ycrcb_2_rgb, rgb_2_ycrcb
-from .spatial_steerable_pyramid import SpatialSteerablePyramid
+from .spatial_steerable_pyramid import SpatialSteerablePyramid, pad_image_for_pyramid
 from .radially_varying_blur import RadiallyVaryingBlur
 from .foveation import make_radial_map
 
@@ -132,17 +132,8 @@ class MetamericLossUniform():
             raise Exception(
                 "MetamericLoss ERROR: Input and target must have same number of channels.")
         # Pad image and target if necessary
-        min_divisor = 2**self.n_pyramid_levels
-        height = image.size(2)
-        width = image.size(3)
-        required_height = math.ceil(height/min_divisor)*min_divisor
-        required_width = math.ceil(width/min_divisor)*min_divisor
-        if required_height > height or required_width > width:
-            # We need to pad!
-            pad = torch.nn.ReflectionPad2d(
-                (0, 0, required_height-height, required_width-width))
-            image = pad(image)
-            target = pad(target)
+        image = pad_image_for_pyramid(image, self.n_pyramid_levels)
+        target = pad_image_for_pyramid(target, self.n_pyramid_levels)
         if image.size(1) == 3 and image_colorspace == "RGB":
             image = rgb_2_ycrcb(image)
             target = rgb_2_ycrcb(target)

--- a/odak/learn/perception/radially_varying_blur.py
+++ b/odak/learn/perception/radially_varying_blur.py
@@ -23,7 +23,7 @@ class RadiallyVaryingBlur():
     def __init__(self):
         self.lod_map = None
 
-    def blur(self, image, alpha=0.08, real_image_width=0.2, real_viewing_distance=0.7, centre=None, mode="quadratic"):
+    def blur(self, image, alpha=0.2, real_image_width=0.2, real_viewing_distance=0.7, centre=None, mode="quadratic"):
         """
         Apply the radially varying blur to an image.
 

--- a/odak/learn/perception/spatial_steerable_pyramid.py
+++ b/odak/learn/perception/spatial_steerable_pyramid.py
@@ -4,6 +4,19 @@ import numpy as np
 import math
 
 def pad_image_for_pyramid(image, n_pyramid_levels):
+    """
+    Pads an image to the extent necessary to compute a steerable pyramid of the input image.
+    This involves padding so both height and width are divisible by 2**n_pyramid_levels.
+    Uses reflection padding.
+
+    Parameters
+    ----------
+
+    image: torch.tensor
+        Image to pad, in NCHW format
+    n_pyramid_levels: int
+        Number of levels in the pyramid you plan to construct.
+    """
     min_divisor = 2 ** n_pyramid_levels
     height = image.size(2)
     width = image.size(3)

--- a/odak/learn/perception/steerable_pyramid_filters.py
+++ b/odak/learn/perception/steerable_pyramid_filters.py
@@ -38,10 +38,6 @@ def crop_steerable_pyramid_filters(filters, size):
     sum_l0 = torch.sum(filters["l0"])
     filters["l0"] = crop_filter(filters["l0"], 2, normalise=False)
     filters["l0"] *= sum_l0 / torch.sum(filters["l0"])
-    # l0_sum = torch.sum(filters["l0"])
-    # filters["l0"] = crop_filter(filters["l0"], r)
-    # filters["l0"] /= torch.sum(filters["l0"])
-    # filters["l0"] *= l0_sum
     for b in range(len(filters["b"])):
         filters["b"][b] = crop_filter(filters["b"][b], r, normalise=True)
     return filters


### PR DESCRIPTION
Corrected an error in the maths to calculate the size of pooling regions, which meant they were too large. Changed default values of "alpha" foveation parameter so foveation effect at default settings is similar.
This shouldn't affect use of the perceptual losses, but will mean functions in foveation.py will produce correct output if used on their own.