### PR TITLE
self_attention_layer --> non_local_block / sofmat only

### DIFF
--- a/odak/learn/models/components.py
+++ b/odak/learn/models/components.py
@@ -328,7 +328,7 @@ class residual_attention_layer(torch.nn.Module):
         return result
 
  
-class self_attention_layer(torch.nn.Module):
+class non_local_layer(torch.nn.Module):
     """
     Self-Attention Layer [zi = Wzyi + xi] (non-local block : ref https://arxiv.org/abs/1711.07971)
     """
@@ -352,7 +352,7 @@ class self_attention_layer(torch.nn.Module):
         bias                : bool 
                               Set to True to let convolutional layers have bias term.
         """
-        super(self_attention_layer, self).__init__()
+        super(non_local_layer, self).__init__()
         self.input_channels = input_channels
         self.bottleneck_channels = bottleneck_channels
         self.g = torch.nn.Conv2d(

--- a/odak/learn/models/components.py
+++ b/odak/learn/models/components.py
@@ -338,7 +338,6 @@ class self_attention_layer(torch.nn.Module):
                  bottleneck_channels = 512,
                  kernel_size = 1,
                  bias = False,
-                 activation = torch.nn.ReLU()
                 ):
         """
 
@@ -352,8 +351,6 @@ class self_attention_layer(torch.nn.Module):
                               Kernel size.
         bias                : bool 
                               Set to True to let convolutional layers have bias term.
-        activation          : torch.nn
-                              Non-linear activation layer (e.g., torch.nn.ReLU(), torch.nn.Sigmoid()).
         """
         super(self_attention_layer, self).__init__()
         self.input_channels = input_channels


### PR DESCRIPTION
 non_local_block (old self_attention_layer) does not have any other activation function like nn.ReLU(), since softmax is only needed to get probability dist. [0-1]as it is a proposed attention mechanism.
I also changed to non_local_block as it is in original paper, and keep use the same name with the research community. 