### PR TITLE
self_attention_layer --> non_local_layer, activation func pass removed

### DIFF
--- a/odak/learn/models/components.py
+++ b/odak/learn/models/components.py
@@ -328,7 +328,7 @@ class residual_attention_layer(torch.nn.Module):
         return result
 
  
-class self_attention_layer(torch.nn.Module):
+class non_local_layer(torch.nn.Module):
     """
     Self-Attention Layer [zi = Wzyi + xi] (non-local block : ref https://arxiv.org/abs/1711.07971)
     """
@@ -352,7 +352,7 @@ class self_attention_layer(torch.nn.Module):
         bias                : bool 
                               Set to True to let convolutional layers have bias term.
         """
-        super(self_attention_layer, self).__init__()
+        super(non_local_layer, self).__init__()
         self.input_channels = input_channels
         self.bottleneck_channels = bottleneck_channels
         self.g = torch.nn.Conv2d(

--- a/odak/learn/models/components.py
+++ b/odak/learn/models/components.py
@@ -338,7 +338,6 @@ class self_attention_layer(torch.nn.Module):
                  bottleneck_channels = 512,
                  kernel_size = 1,
                  bias = False,
-                 activation = torch.nn.ReLU()
                 ):
         """
 
@@ -352,8 +351,6 @@ class self_attention_layer(torch.nn.Module):
                               Kernel size.
         bias                : bool 
                               Set to True to let convolutional layers have bias term.
-        activation          : torch.nn
-                              Non-linear activation layer (e.g., torch.nn.ReLU(), torch.nn.Sigmoid()).
         """
         super(self_attention_layer, self).__init__()
         self.input_channels = input_channels

--- a/test/test_learn_components.py
+++ b/test/test_learn_components.py
@@ -25,10 +25,10 @@ def test():
     y = residual_attention_layer_inference(x , x)
     print(y.shape)
     # test self-attention layer
-    self_attention_layer_inference = components.self_attention_layer(input_channels=2,
+    non_local_layer_inference = components.non_local_layer(input_channels=2,
                                                                       bottleneck_channels=1
                                                                       )
-    z = self_attention_layer_inference(x)
+    z = non_local_layer_inference(x)
     print(z.shape)
     assert True == True
 


### PR DESCRIPTION
The class's name change is proposed to better align with research papers and community, the activation function option is removed as it must be a probability dist. between [0-1], ReLU can not provide this. 
The test is updated with the new name. 
