### PR TITLE
Update function "custom" in classical.py

### DIFF
--- a/odak/learn/wave/classical.py
+++ b/odak/learn/wave/classical.py
@@ -197,12 +197,12 @@ def custom(field, kernel, zero_padding = False, aperture = 1.):
         H = torch.ones(field.shape).to(field.device)
     else:
         H = kernel * aperture
-    U1 = torch.fft.fftshift(torch.fft.fft2(torch.fft.fftshift(field))) * aperture
+    U1 = torch.fft.fftshift(torch.fft.fft2(field)) * aperture
     if zero_padding == False:
         U2 = H * U1
     elif zero_padding == True:
         U2 = zero_pad(H * U1)
-    result = torch.fft.ifftshift(torch.fft.ifft2(torch.fft.ifftshift(U2)))
+    result = torch.fft.ifft2(torch.fft.ifftshift(U2))
     return result
 
 


### PR DESCRIPTION
# remove "torch.fft.fftshift" and "torch.fft.ifftshift" which may help accelerate the program

## Validated by the following 2 tests

### When the number of the sampling points is odd
```python
import torch

# odd
field_padded = torch.rand(3,3)
H =torch.rand(3,3)
aperture = torch.rand(3,3)

# original code
U1_1 = torch.fft.fftshift(torch.fft.fft2(torch.fft.fftshift(field_padded)))
U2_1 = H * aperture * U1_1
result_1 = torch.fft.ifftshift(torch.fft.ifft2(torch.fft.ifftshift(U2_1)))

# remove the fftshift and ifftshift in the spatial domain
U1_2 = torch.fft.fftshift(torch.fft.fft2(field_padded))
U2_2 = H * aperture * U1_2
result_2 = torch.fft.ifft2(torch.fft.ifftshift(U2_2))

print(U1_1)
print(U1_2)

assert torch.allclose(result_1, result_2)
```

![image](https://github.com/kaanaksit/odak/assets/146353349/9de8b02a-48f3-433b-bbc2-bbb2878f4adc)


### When the number of the sampling points is even
```python
import torch

# even
field_padded = torch.rand(4,4)
H =torch.rand(4,4)
aperture = torch.rand(4,4)

# original code
U1_1 = torch.fft.fftshift(torch.fft.fft2(torch.fft.fftshift(field_padded)))
U2_1 = H * aperture * U1_1
result_1 = torch.fft.ifftshift(torch.fft.ifft2(torch.fft.ifftshift(U2_1)))

# remove the fftshift and ifftshift in the spatial domain
U1_2 = torch.fft.fftshift(torch.fft.fft2(field_padded))
U2_2 = H * aperture * U1_2
result_2 = torch.fft.ifft2(torch.fft.ifftshift(U2_2))

print(U1_1)
print(U1_2)

assert torch.allclose(result_1, result_2)
```

![image](https://github.com/kaanaksit/odak/assets/146353349/fdabdad0-d472-4926-a838-5c288ec0a8eb)
