### PR TITLE
Add unit tests for query_llm, update THANKS.txt and CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -83,6 +83,10 @@ authors:
   - family-names: Yang
     given-names: Xinge
     orcid:  https://orcid.org/0000-0002-4936-1347
+  
+  - family-names: Tekin
+    given-names: Servet Efe
+    orcid:  https://orcid.org/0009-0003-7881-7360
 
 
 title: "Odak"

--- a/THANKS.txt
+++ b/THANKS.txt
@@ -19,3 +19,4 @@ Ziyang Chen
 Yicheng Zhan
 Yiyang Wu
 Xinge Yang
+Servet Efe Tekin

--- a/odak/tools/large_language_model.py
+++ b/odak/tools/large_language_model.py
@@ -1,4 +1,6 @@
-import requests
+import json
+import urllib.request
+
 
 def query_llm(
     prompt,
@@ -63,15 +65,22 @@ def query_llm(
         },
     }
 
-    response = requests.post(
+    request = urllib.request.Request(
         url,
-        json=payload,
-        timeout=timeout,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={
+            "Content-Type": "application/json",
+        },
+        method="POST",
     )
 
-    response.raise_for_status()
-
-    data = response.json()
+    with urllib.request.urlopen(
+        request,
+        timeout=timeout,
+    ) as response:
+        data = json.loads(
+            response.read().decode("utf-8")
+        )
 
     if "message" not in data:
         raise ValueError(

--- a/test/test_tools_query_llm.py
+++ b/test/test_tools_query_llm.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from unittest.mock import Mock, patch
 
@@ -5,34 +6,38 @@ from odak.tools.large_language_model import query_llm
 
 
 class TestQueryLLM(unittest.TestCase):
-    @patch("odak.tools.large_language_model.requests.post")
-    def test_query_llm_returns_response(self, mock_post):
+    def mock_urlopen_response(self, data):
         mock_response = Mock()
-        mock_response.json.return_value = {"message": {"content": "response"}}
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+        mock_response.read.return_value = json.dumps(data).encode("utf-8")
+        mock_response.__enter__ = Mock(return_value=mock_response)
+        mock_response.__exit__ = Mock(return_value=None)
+        return mock_response
+
+    @patch("odak.tools.large_language_model.urllib.request.urlopen")
+    def test_query_llm_returns_response(self, mock_urlopen):
+        mock_urlopen.return_value = self.mock_urlopen_response(
+            {"message": {"content": "response"}}
+        )
 
         response = query_llm("Hello")
 
         self.assertEqual(response, "response")
 
-    @patch("odak.tools.large_language_model.requests.post")
-    def test_query_llm_strips_response(self, mock_post):
-        mock_response = Mock()
-        mock_response.json.return_value = {"message": {"content": "  response  \n"}}
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+    @patch("odak.tools.large_language_model.urllib.request.urlopen")
+    def test_query_llm_strips_response(self, mock_urlopen):
+        mock_urlopen.return_value = self.mock_urlopen_response(
+            {"message": {"content": "  response  \n"}}
+        )
 
         response = query_llm("Hello")
 
         self.assertEqual(response, "response")
 
-    @patch("odak.tools.large_language_model.requests.post")
-    def test_query_llm_uses_custom_parameters(self, mock_post):
-        mock_response = Mock()
-        mock_response.json.return_value = {"message": {"content": "response"}}
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+    @patch("odak.tools.large_language_model.urllib.request.urlopen")
+    def test_query_llm_uses_custom_parameters(self, mock_urlopen):
+        mock_urlopen.return_value = self.mock_urlopen_response(
+            {"message": {"content": "response"}}
+        )
 
         query_llm(
             "Hello",
@@ -45,30 +50,29 @@ class TestQueryLLM(unittest.TestCase):
             timeout=5,
         )
 
-        args, kwargs = mock_post.call_args
+        request = mock_urlopen.call_args[0][0]
 
-        self.assertEqual(args[0], "http://1.2.3.4:9999/api/chat")
-        self.assertEqual(kwargs["timeout"], 5)
-        self.assertEqual(kwargs["json"]["model"], "test-model")
-        self.assertEqual(kwargs["json"]["options"]["temperature"], 0.1)
-        self.assertEqual(kwargs["json"]["options"]["num_predict"], 20)
+        self.assertEqual(request.full_url, "http://1.2.3.4:9999/api/chat")
+        self.assertEqual(mock_urlopen.call_args.kwargs["timeout"], 5)
 
-    @patch("odak.tools.large_language_model.requests.post")
-    def test_query_llm_missing_message_raises_value_error(self, mock_post):
-        mock_response = Mock()
-        mock_response.json.return_value = {}
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+        payload = json.loads(request.data.decode("utf-8"))
+
+        self.assertEqual(payload["model"], "test-model")
+        self.assertEqual(payload["options"]["temperature"], 0.1)
+        self.assertEqual(payload["options"]["num_predict"], 20)
+
+    @patch("odak.tools.large_language_model.urllib.request.urlopen")
+    def test_query_llm_missing_message_raises_value_error(self, mock_urlopen):
+        mock_urlopen.return_value = self.mock_urlopen_response({})
 
         with self.assertRaises(ValueError):
             query_llm("Hello")
 
-    @patch("odak.tools.large_language_model.requests.post")
-    def test_query_llm_missing_content_raises_value_error(self, mock_post):
-        mock_response = Mock()
-        mock_response.json.return_value = {"message": {}}
-        mock_response.raise_for_status.return_value = None
-        mock_post.return_value = mock_response
+    @patch("odak.tools.large_language_model.urllib.request.urlopen")
+    def test_query_llm_missing_content_raises_value_error(self, mock_urlopen):
+        mock_urlopen.return_value = self.mock_urlopen_response(
+            {"message": {}}
+        )
 
         with self.assertRaises(ValueError):
             query_llm("Hello")

--- a/test/test_tools_query_llm.py
+++ b/test/test_tools_query_llm.py
@@ -1,0 +1,82 @@
+import unittest
+from unittest.mock import Mock, patch
+
+from odak.tools.large_language_model import query_llm
+
+
+class TestQueryLLM(unittest.TestCase):
+    @patch("odak.tools.large_language_model.requests.post")
+    def test_query_llm_returns_response(self, mock_post):
+        mock_response = Mock()
+        mock_response.json.return_value = {"message": {"content": "response"}}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        response = query_llm("Hello")
+
+        self.assertEqual(response, "response")
+
+    @patch("odak.tools.large_language_model.requests.post")
+    def test_query_llm_strips_response(self, mock_post):
+        mock_response = Mock()
+        mock_response.json.return_value = {"message": {"content": "  response  \n"}}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        response = query_llm("Hello")
+
+        self.assertEqual(response, "response")
+
+    @patch("odak.tools.large_language_model.requests.post")
+    def test_query_llm_uses_custom_parameters(self, mock_post):
+        mock_response = Mock()
+        mock_response.json.return_value = {"message": {"content": "response"}}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        query_llm(
+            "Hello",
+            address="1.2.3.4",
+            port=9999,
+            model="test-model",
+            endpoint="/api/chat",
+            temperature=0.1,
+            max_tokens=20,
+            timeout=5,
+        )
+
+        args, kwargs = mock_post.call_args
+
+        self.assertEqual(args[0], "http://1.2.3.4:9999/api/chat")
+        self.assertEqual(kwargs["timeout"], 5)
+        self.assertEqual(kwargs["json"]["model"], "test-model")
+        self.assertEqual(kwargs["json"]["options"]["temperature"], 0.1)
+        self.assertEqual(kwargs["json"]["options"]["num_predict"], 20)
+
+    @patch("odak.tools.large_language_model.requests.post")
+    def test_query_llm_missing_message_raises_value_error(self, mock_post):
+        mock_response = Mock()
+        mock_response.json.return_value = {}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(ValueError):
+            query_llm("Hello")
+
+    @patch("odak.tools.large_language_model.requests.post")
+    def test_query_llm_missing_content_raises_value_error(self, mock_post):
+        mock_response = Mock()
+        mock_response.json.return_value = {"message": {}}
+        mock_response.raise_for_status.return_value = None
+        mock_post.return_value = mock_response
+
+        with self.assertRaises(ValueError):
+            query_llm("Hello")
+
+    def test_query_llm_requires_string_prompt(self):
+        with self.assertRaises(TypeError):
+            query_llm(123)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds unit tests for the query_llm utility function, including:

- Valid response handling
- Response whitespace stripping
- Custom parameter handling
- Invalid prompt type validation
- Missing "message" field validation
- Missing "content" field validation